### PR TITLE
ユニットテストが通るロジックの実装

### DIFF
--- a/app/src/main/java/com/example/pokerapplication/PokerHands.kt
+++ b/app/src/main/java/com/example/pokerapplication/PokerHands.kt
@@ -10,6 +10,26 @@ object PokerHands {
      * @return　役に対応する文字列
      */
     fun makeHands(input: String): String {
-        return "--"
+        return Hand.fromOrder(
+            Regex("[SHDC][^SHDC]+").findAll(input)
+                .map { it.groupValues[0] }
+                .groupBy { it.substring(1) } // drop SDHC
+                .map { it.value.count() }
+                .sortedDescending()
+                .joinToString("")
+        ).symbol
+    }
+}
+
+enum class Hand(val symbol: String, val order: String) {
+    FourCard("4K", "41"),
+    FullHouse("FH", "32"),
+    ThreeCard("3K", "311"),
+    TwoPair("2P", "221"),
+    OnePair("1P", "2111"),
+    None("--", "11111");
+
+    companion object {
+        fun fromOrder(card: String): Hand = values().firstOrNull { it.order == card } ?: None
     }
 }

--- a/app/src/test/java/com/example/pokerapplication/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/pokerapplication/ExampleUnitTest.kt
@@ -54,4 +54,11 @@ class ExampleUnitTest {
         val output = PokerHands.makeHands(input)
         assertEquals("--", output)
     }
+
+    @Test
+    fun test_exception() {
+        val input = "sugoi"
+        val output = PokerHands.makeHands(input)
+        assertEquals("--", output)
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 27 21:34:46 JST 2019
+#Mon Jun 01 21:33:47 JST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
# 内容
Unit Testが通るよう実装

## 実装
### 役
役は名前とペアになった枚数を定義したEnumで表現。
役なしは`--/11111`(5枚すべて異なる＝各数字が1枚ずつ) で表す。

### 役の判定
必ずSHDC＋数字の繰り返しであるという前提で、
文字の組を正義表現によりペアの枚数を判定する実装。
INPUTが`D3C3C10D10S3` の場合、
1. マーク＋数でグループ化 // `[["D3"],["C3"],["C10"],["D10"],["S3"]]`
1. 数のみを抽出 // `["3","3","10","10","3"]`
1. 数値部分でグループ化 // `[["3", "3"], ["10", "10", "10"]]`
1. グループ内要素の個数でリスト化 // `[2, 3]`
1. 降順に整形 // `[3, 2]`
1. 役の型にマッチしたものを返す（`3,2`がマッチするフルハウス）